### PR TITLE
Install the ign-launch executable

### DIFF
--- a/ubuntu/debian/libignition-launch-dev.install
+++ b/ubuntu/debian/libignition-launch-dev.install
@@ -2,5 +2,6 @@ usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/ignition-launch*/*
+usr/lib/*/ignition/launch*/*
 usr/share/*
 usr/lib/ruby/*


### PR DESCRIPTION
Fix an unstable build:

~~~
dh_missing --list-missing
dh_missing: warning: usr/lib/x86_64-linux-gnu/ignition/launch5/ign-launch exists in debian/tmp but is not installed to anywhere
~~~

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-launch5-debbuilder&build=251)](https://build.osrfoundation.org/job/ign-launch5-debbuilder/251/) https://build.osrfoundation.org/job/ign-launch5-debbuilder/251/